### PR TITLE
Gesture precedence in watchOS

### DIFF
--- a/Examples/PageViewDemo WatchKit Extension/ContentView.swift
+++ b/Examples/PageViewDemo WatchKit Extension/ContentView.swift
@@ -13,9 +13,9 @@ struct ContentView: View {
     var body: some View {
         // Horizontal
         HPageView {
-            CustomView()
-            CustomListView()
-            CustomView()
+            CustomButtonView()
+            CustomButtonView()
+            CustomButtonView()
             CustomView()
             CustomView()
             CustomView()

--- a/Examples/PageViewDemo WatchKit Extension/ContentView.swift
+++ b/Examples/PageViewDemo WatchKit Extension/ContentView.swift
@@ -17,14 +17,14 @@ struct ContentView: View {
             CustomButtonView()
             CustomButtonView()
             CustomView()
-            CustomView()
+            CustomListView()
             CustomView()
         }.edgesIgnoringSafeArea(.init(arrayLiteral: .leading, .trailing, .bottom))
         // Vertical
 //        VPageView {
-//            CustomView()
-//            CustomListView()
-//            CustomView()
+//            CustomButtonView()
+//            CustomButtonView()
+//            CustomButtonView()
 //            CustomView()
 //            CustomView()
 //            CustomView()

--- a/Examples/PageViewDemo/Views.swift
+++ b/Examples/PageViewDemo/Views.swift
@@ -14,6 +14,23 @@ extension View {
     }
 }
 
+struct CustomButtonView: View {
+    var body: some View {
+        VStack {
+            Button(action: {
+                print("Button 1 tapped")
+            }, label: {
+                Text("Button 1")
+            })
+            Button(action: {
+                print("Button 2 tapped")
+            }, label: {
+                Text("Button 2")
+            })
+        }
+    }
+}
+
 struct CustomView: View {
     var body: some View {
         VStack {

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -40,10 +40,10 @@ public struct HPageView<Pages>: View where Pages: View {
                         compositeView: HorizontalPageStack(pages: self.pages, geometry: geometry),
                         pageControlBuilder: pageControlBuilder)
                 .contentShape(Rectangle())
-                   .gesture(DragGesture(minimumDistance: 8.0)
-                       .onChanged({ self.onDragChanged($0, geometry: geometry) })
-                       .onEnded({ self.onDragEnded($0, geometry: geometry) })
-                   )
+                .highPriorityGesture(DragGesture(minimumDistance: 8.0)
+                    .onChanged({ self.onDragChanged($0, geometry: geometry) })
+                    .onEnded({ self.onDragEnded($0, geometry: geometry) })
+                )
         }
     }
     
@@ -89,10 +89,10 @@ public struct VPageView<Pages>: View where Pages: View {
                         compositeView: VerticalPageStack(pages: self.pages, geometry: geometry),
                         pageControlBuilder: pageControlBuilder)
                 .contentShape(Rectangle())
-                   .gesture(DragGesture(minimumDistance: 8.0)
-                       .onChanged({ self.onDragChanged($0, geometry: geometry) })
-                       .onEnded({ self.onDragEnded($0, geometry: geometry) })
-                   )
+                .highPriorityGesture(DragGesture(minimumDistance: 8.0)
+                    .onChanged({ self.onDragChanged($0, geometry: geometry) })
+                    .onEnded({ self.onDragEnded($0, geometry: geometry) })
+                )
         }
     }
     


### PR DESCRIPTION
Attemp to fix #2.

Drag gesture should have higher precedence than any other content view gesture.