### PR TITLE
Switch to simultaneousGesture

### DIFF
--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -49,7 +49,7 @@ public struct HPageView<Pages>: View where Pages: View {
                         compositeView: HorizontalPageStack(pages: self.pages, geometry: geometry),
                         pageControlBuilder: pageControlBuilder)
                 .contentShape(Rectangle())
-                .highPriorityGesture(DragGesture(minimumDistance: 8.0)
+                .simultaneousGesture(DragGesture(minimumDistance: 8.0)
                     .updating(self.$stateTransaction, body: { value, state, _ in
                         state.dragValue = value
                         state.geometryProxy = geometry
@@ -110,7 +110,7 @@ public struct VPageView<Pages>: View where Pages: View {
                         compositeView: VerticalPageStack(pages: self.pages, geometry: geometry),
                         pageControlBuilder: pageControlBuilder)
                 .contentShape(Rectangle())
-                .highPriorityGesture(DragGesture(minimumDistance: 8.0)
+                .simultaneousGesture(DragGesture(minimumDistance: 8.0)
                     .updating(self.$stateTransaction, body: { value, state, _ in
                         state.dragValue = value
                         state.geometryProxy = geometry


### PR DESCRIPTION
Gesture priorities are set as high, in some cases `PageView` will prevent other gestures from working.