### PR TITLE
Improved customization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "PageView",
     platforms: [
         .iOS(.v14),
-        .watchOS(.v6)
+        .watchOS(.v7)
     ],
     products: [
         .library(name: "PageView", targets: ["PageView"]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PageView",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v14),
         .watchOS(.v6)
     ],
     products: [

--- a/Sources/PageContent.swift
+++ b/Sources/PageContent.swift
@@ -42,6 +42,7 @@ struct VerticalPageStack<Pages>: View where Pages: View {
 }
 
 struct PageContent<Stack, Control>: View where Stack: View, Control: View {
+    @Binding var selectedPage: Int
     @ObservedObject var state: PageScrollState
     let compositeView: Stack
     let childCount: Int
@@ -51,7 +52,8 @@ struct PageContent<Stack, Control>: View where Stack: View, Control: View {
     let geometry: GeometryProxy
     private let baseOffset: CGFloat
     
-    init(state: PageScrollState, axis: Axis, alignment: Alignment, geometry: GeometryProxy, childCount: Int, compositeView: Stack, pageControlBuilder: @escaping (Int, Binding<Int>) -> Control) {
+    init(selectedPage: Binding<Int>, state: PageScrollState, axis: Axis, alignment: Alignment, geometry: GeometryProxy, childCount: Int, compositeView: Stack, pageControlBuilder: @escaping (Int, Binding<Int>) -> Control) {
+        self._selectedPage = selectedPage
         self.state = state
         self.compositeView = compositeView
         self.childCount = childCount
@@ -67,7 +69,7 @@ struct PageContent<Stack, Control>: View where Stack: View, Control: View {
     }
     
     var body: some View {
-        let pageControl = pageControlBuilder(childCount, $state.selectedPage)
+        let pageControl = pageControlBuilder(childCount, $selectedPage)
         
         return ZStack(alignment: .center) {
             compositeView
@@ -92,17 +94,17 @@ struct PageContent<Stack, Control>: View where Stack: View, Control: View {
     
     private func horizontalOffset(using geometry: GeometryProxy) -> CGFloat {
         if state.isGestureActive {
-            return baseOffset + -1 * CGFloat(state.selectedPage) * geometry.size.width + state.pageOffset
+            return baseOffset + -1 * CGFloat(selectedPage) * geometry.size.width + state.pageOffset
         } else {
-            return baseOffset + -1 * CGFloat(state.selectedPage) * geometry.size.width
+            return baseOffset + -1 * CGFloat(selectedPage) * geometry.size.width
         }
     }
     
     private func verticalOffset(using geometry: GeometryProxy) -> CGFloat {
         if state.isGestureActive {
-            return baseOffset + -1 * CGFloat(state.selectedPage) * geometry.size.height + state.pageOffset
+            return baseOffset + -1 * CGFloat(selectedPage) * geometry.size.height + state.pageOffset
         } else {
-            return baseOffset + -1 * CGFloat(state.selectedPage) * geometry.size.height
+            return baseOffset + -1 * CGFloat(selectedPage) * geometry.size.height
         }
     }
 }

--- a/Sources/PageControl.swift
+++ b/Sources/PageControl.swift
@@ -38,6 +38,7 @@ public enum PageControl {
             }
                 .modifier(Background(theme: theme))
                 .offset(x: 0.0, y: theme.yOffset)
+                .opacity(theme.opacity)
         }
     }
 
@@ -55,6 +56,7 @@ public enum PageControl {
             }
                 .modifier(Background(theme: theme))
                 .offset(x: theme.xOffset, y: 0.0)
+                .opacity(theme.opacity)
         }
     }
     

--- a/Sources/PageControlTheme.swift
+++ b/Sources/PageControlTheme.swift
@@ -16,6 +16,7 @@ public struct PageControlTheme {
     public var padding: CGFloat
     public var xOffset: CGFloat
     public var yOffset: CGFloat
+    public var opacity: Double
     public var alignment: Alignment?
     
     public init(
@@ -27,6 +28,7 @@ public struct PageControlTheme {
         padding: CGFloat,
         xOffset: CGFloat,
         yOffset: CGFloat,
+        opacity: Double = 1.0,
         alignment: Alignment? = nil
     ) {
         self.backgroundColor = backgroundColor
@@ -37,8 +39,20 @@ public struct PageControlTheme {
         self.padding = padding
         self.xOffset = xOffset
         self.yOffset = yOffset
+        self.opacity = opacity
         self.alignment = alignment
     }
+
+    public static let invisible: PageControlTheme = PageControlTheme(backgroundColor: .clear,
+                                                                     dotActiveColor: .clear,
+                                                                     dotInactiveColor: .clear,
+                                                                     dotSize: .zero,
+                                                                     spacing: .zero,
+                                                                     padding: .zero,
+                                                                     xOffset: .zero,
+                                                                     yOffset: .zero,
+                                                                     opacity: .zero,
+                                                                     alignment: nil)
     
     public static var `default`: PageControlTheme {
         #if os(iOS)

--- a/Sources/PageScrollState.swift
+++ b/Sources/PageScrollState.swift
@@ -8,29 +8,31 @@
 import SwiftUI
 
 class PageScrollState: ObservableObject {
-    
-    // MARK: Types
-    
-    struct TransactionInfo {
-        var dragValue: DragGesture.Value!
-        var geometryProxy: GeometryProxy!
-    }
-    
     // MARK: Properties
-    
-    let switchThreshold: CGFloat
-    @Binding var selectedPage: Int
     @Published var pageOffset: CGFloat = 0.0
     @Published var isGestureActive: Bool = false
-    
-    init(switchThreshold: CGFloat, selectedPageBinding: Binding<Int>) {
-        self.switchThreshold = switchThreshold
-        self._selectedPage = selectedPageBinding
+
+    func willAcceptHorizontalDrag(_ value: DragGesture.Value, pageWidth: CGFloat, settings: PageViewSettings) -> Bool {
+        guard settings.dragEnabled else { return false }
+
+        let allowedRange = pageWidth * settings.dragEdgeThreshold
+
+        return (0 ... allowedRange).contains(value.startLocation.x) || (pageWidth - allowedRange ... pageWidth).contains(value.startLocation.x)
+    }
+
+    func willAcceptVerticalDrag(_ value: DragGesture.Value, pageHeight: CGFloat, settings: PageViewSettings) -> Bool {
+        guard settings.dragEnabled else { return false }
+
+        let allowedRange = pageHeight * settings.dragEdgeThreshold
+
+        return (0 ... allowedRange).contains(value.startLocation.y) || (pageHeight - allowedRange ... pageHeight).contains(value.startLocation.y)
     }
     
     // MARK: DragGesture callbacks
     
-    func horizontalDragChanged(_ value: DragGesture.Value, viewCount: Int, pageWidth: CGFloat) {
+    func horizontalDragChanged(_ value: DragGesture.Value, viewCount: Int, pageWidth: CGFloat, settings: PageViewSettings, selectedPage: Int) {
+        guard willAcceptHorizontalDrag(value, pageWidth: pageWidth, settings: settings) else { return }
+
         isGestureActive = true
         let delta = value.translation.width
         if (delta > 0 && selectedPage == 0) || (delta < 0 && selectedPage == viewCount - 1) {
@@ -40,11 +42,15 @@ class PageScrollState: ObservableObject {
         }
     }
     
-    func horizontalDragEnded(_ value: DragGesture.Value, viewCount: Int, pageWidth: CGFloat) {
-        dragEnded(value, viewCount: viewCount, dimension: pageWidth)
+    func horizontalDragEnded(_ value: DragGesture.Value, viewCount: Int, pageWidth: CGFloat, settings: PageViewSettings, selectedPage: Binding<Int>) {
+        guard willAcceptHorizontalDrag(value, pageWidth: pageWidth, settings: settings) else { return }
+
+        dragEnded(value, viewCount: viewCount, dimension: pageWidth, settings: settings, selectedPage: selectedPage)
     }
     
-    func verticalDragChanged(_ value: DragGesture.Value, viewCount: Int, pageHeight: CGFloat) {
+    func verticalDragChanged(_ value: DragGesture.Value, viewCount: Int, pageHeight: CGFloat, settings: PageViewSettings, selectedPage: Int) {
+        guard willAcceptVerticalDrag(value, pageHeight: pageHeight, settings: settings) else { return }
+
         isGestureActive = true
         let delta = value.translation.height
         if (delta > 0 && selectedPage == 0) || (delta < 0 && selectedPage == viewCount - 1) {
@@ -54,43 +60,27 @@ class PageScrollState: ObservableObject {
         }
     }
     
-    func verticalDragEnded(_ value: DragGesture.Value, viewCount: Int, pageHeight: CGFloat) {
-        dragEnded(value, viewCount: viewCount, dimension: pageHeight)
+    func verticalDragEnded(_ value: DragGesture.Value, viewCount: Int, pageHeight: CGFloat, settings: PageViewSettings, selectedPage: Binding<Int>) {
+        guard willAcceptVerticalDrag(value, pageHeight: pageHeight, settings: settings) else { return }
+
+        dragEnded(value, viewCount: viewCount, dimension: pageHeight, settings: settings, selectedPage: selectedPage)
     }
     
-    private func dragEnded(_ value: DragGesture.Value, viewCount: Int, dimension: CGFloat) {
-        var newPage = selectedPage
-        if pageOffset > switchThreshold*dimension && selectedPage != 0 {
+    private func dragEnded(_ value: DragGesture.Value, viewCount: Int, dimension: CGFloat, settings: PageViewSettings, selectedPage: Binding<Int>) {
+        var newPage = selectedPage.wrappedValue
+        if pageOffset > settings.switchThreshold * dimension && selectedPage.wrappedValue != 0 {
             newPage -= 1
-        } else if pageOffset < -switchThreshold*dimension && selectedPage != viewCount - 1 {
+        } else if pageOffset < -settings.switchThreshold * dimension && selectedPage.wrappedValue != viewCount - 1 {
             newPage += 1
         }
         
         withAnimation(.easeInOut(duration: 0.2)) {
-            self.pageOffset = 0.0
-            self.selectedPage = newPage
+            pageOffset = 0.0
+            selectedPage.wrappedValue = newPage
         }
         
         DispatchQueue.main.async {
             self.isGestureActive = false
-        }
-    }
-    
-    // MARK: Gesture States
-    
-    func horizontalGestureState(pageCount: Int) -> GestureState<TransactionInfo> {
-        return GestureState(initialValue: TransactionInfo()) { [weak self] (info, _) in
-            let width = info.geometryProxy.size.width
-            let dragValue = info.dragValue!
-            self?.horizontalDragEnded(dragValue, viewCount: pageCount, pageWidth: width)
-        }
-    }
-    
-    func verticalGestureState(pageCount: Int) -> GestureState<TransactionInfo> {
-        return GestureState(initialValue: TransactionInfo()) { [weak self] (info, _) in
-            let height = info.geometryProxy.size.height
-            let dragValue = info.dragValue!
-            self?.verticalDragEnded(dragValue, viewCount: pageCount, pageHeight: height)
         }
     }
 }

--- a/Sources/PageScrollState.swift
+++ b/Sources/PageScrollState.swift
@@ -7,8 +7,11 @@
 
 import SwiftUI
 
+public enum PageGestureType {
+    case disabled, standard, simultaneous, highPriority
+}
+
 class PageScrollState: ObservableObject {
-    
     // MARK: Types
     
     struct TransactionInfo {
@@ -20,21 +23,21 @@ class PageScrollState: ObservableObject {
     
     let switchThreshold: CGFloat
     let edgeSwipeThreshold: CGFloat
-    let pageSwitchingAllowed: Bool
+    let pageGestureType: PageGestureType
 
     @Binding var selectedPage: Int
     @Published var pageOffset: CGFloat = 0.0
     @Published var isGestureActive: Bool = false
     
-    init(switchThreshold: CGFloat, edgeSwipeThreshold: CGFloat, pageSwitchingAllowed: Bool, selectedPageBinding: Binding<Int>) {
+    init(switchThreshold: CGFloat, edgeSwipeThreshold: CGFloat, pageGestureType: PageGestureType, selectedPageBinding: Binding<Int>) {
         self.switchThreshold = switchThreshold
         self.edgeSwipeThreshold = edgeSwipeThreshold
-        self.pageSwitchingAllowed = pageSwitchingAllowed
+        self.pageGestureType = pageGestureType
         self._selectedPage = selectedPageBinding
     }
 
     func willAcceptHorizontalDrag(_ value: DragGesture.Value, pageWidth: CGFloat) -> Bool {
-        guard pageSwitchingAllowed else { return false }
+        guard pageGestureType != .disabled else { return false }
 
         let allowedRange = pageWidth * edgeSwipeThreshold
 
@@ -42,7 +45,7 @@ class PageScrollState: ObservableObject {
     }
 
     func willAcceptVerticalDrag(_ value: DragGesture.Value, pageHeight: CGFloat) -> Bool {
-        guard pageSwitchingAllowed else { return false }
+        guard pageGestureType != .disabled else { return false }
 
         let allowedRange = pageHeight * edgeSwipeThreshold
 

--- a/Sources/PageScrollState.swift
+++ b/Sources/PageScrollState.swift
@@ -20,21 +20,21 @@ class PageScrollState: ObservableObject {
     
     let switchThreshold: CGFloat
     let edgeSwipeThreshold: CGFloat
-    let edgeSwipingAllowed: Bool
+    let pageSwitchingAllowed: Bool
 
     @Binding var selectedPage: Int
     @Published var pageOffset: CGFloat = 0.0
     @Published var isGestureActive: Bool = false
     
-    init(switchThreshold: CGFloat, edgeSwipeThreshold: CGFloat, edgeSwipingAllowed: Bool, selectedPageBinding: Binding<Int>) {
+    init(switchThreshold: CGFloat, edgeSwipeThreshold: CGFloat, pageSwitchingAllowed: Bool, selectedPageBinding: Binding<Int>) {
         self.switchThreshold = switchThreshold
         self.edgeSwipeThreshold = edgeSwipeThreshold
-        self.edgeSwipingAllowed = edgeSwipingAllowed
+        self.pageSwitchingAllowed = pageSwitchingAllowed
         self._selectedPage = selectedPageBinding
     }
 
     func willAcceptHorizontalDrag(_ value: DragGesture.Value, pageWidth: CGFloat) -> Bool {
-        guard edgeSwipingAllowed else { return false }
+        guard pageSwitchingAllowed else { return false }
 
         let allowedRange = pageWidth * edgeSwipeThreshold
 
@@ -42,7 +42,7 @@ class PageScrollState: ObservableObject {
     }
 
     func willAcceptVerticalDrag(_ value: DragGesture.Value, pageHeight: CGFloat) -> Bool {
-        guard edgeSwipingAllowed else { return false }
+        guard pageSwitchingAllowed else { return false }
 
         let allowedRange = pageHeight * edgeSwipeThreshold
 

--- a/Sources/PageScrollState.swift
+++ b/Sources/PageScrollState.swift
@@ -31,22 +31,6 @@ class PageScrollState: ObservableObject {
 
         return (0 ... allowedRange).contains(value.startLocation.y) || (pageHeight - allowedRange ... pageHeight).contains(value.startLocation.y)
     }
-
-    func willAcceptHorizontalDrag(_ value: DragGesture.Value, pageWidth: CGFloat) -> Bool {
-        guard pageGestureType != .disabled else { return false }
-
-        let allowedRange = pageWidth * edgeSwipeThreshold
-
-        return (0 ... allowedRange).contains(value.startLocation.x) || (pageWidth - allowedRange ... pageWidth).contains(value.startLocation.x)
-    }
-
-    func willAcceptVerticalDrag(_ value: DragGesture.Value, pageHeight: CGFloat) -> Bool {
-        guard pageGestureType != .disabled else { return false }
-
-        let allowedRange = pageHeight * edgeSwipeThreshold
-
-        return (0 ... allowedRange).contains(value.startLocation.y) || (pageHeight - allowedRange ... pageHeight).contains(value.startLocation.y)
-    }
     
     // MARK: DragGesture callbacks
     

--- a/Sources/PageScrollState.swift
+++ b/Sources/PageScrollState.swift
@@ -20,23 +20,30 @@ class PageScrollState: ObservableObject {
     
     let switchThreshold: CGFloat
     let edgeSwipeThreshold: CGFloat
+    let edgeSwipingAllowed: Bool
+
     @Binding var selectedPage: Int
     @Published var pageOffset: CGFloat = 0.0
     @Published var isGestureActive: Bool = false
     
-    init(switchThreshold: CGFloat, edgeSwipeThreshold: CGFloat, selectedPageBinding: Binding<Int>) {
+    init(switchThreshold: CGFloat, edgeSwipeThreshold: CGFloat, edgeSwipingAllowed: Bool, selectedPageBinding: Binding<Int>) {
         self.switchThreshold = switchThreshold
         self.edgeSwipeThreshold = edgeSwipeThreshold
+        self.edgeSwipingAllowed = edgeSwipingAllowed
         self._selectedPage = selectedPageBinding
     }
 
     func willAcceptHorizontalDrag(_ value: DragGesture.Value, pageWidth: CGFloat) -> Bool {
+        guard edgeSwipingAllowed else { return false }
+
         let allowedRange = pageWidth * edgeSwipeThreshold
 
         return (0 ... allowedRange).contains(value.startLocation.x) || (pageWidth - allowedRange ... pageWidth).contains(value.startLocation.x)
     }
 
     func willAcceptVerticalDrag(_ value: DragGesture.Value, pageHeight: CGFloat) -> Bool {
+        guard edgeSwipingAllowed else { return false }
+
         let allowedRange = pageHeight * edgeSwipeThreshold
 
         return (0 ... allowedRange).contains(value.startLocation.y) || (pageHeight - allowedRange ... pageHeight).contains(value.startLocation.y)

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -18,12 +18,13 @@ public struct HPageView<Pages>: View where Pages: View {
     public init(
         selectedPage: Binding<Int>,
         pageSwitchThreshold: CGFloat = .defaultSwitchThreshold,
+        edgeSwipeThreshold: CGFloat = .defaultEdgeSwipeThreshold,
         theme: PageControlTheme = .default,
         @PageViewBuilder builder: () -> PageContainer<Pages>
     ) {
         // prevent values outside of 0...1
         let threshold = CGFloat(abs(pageSwitchThreshold) - floor(abs(pageSwitchThreshold)))
-        self.state = PageScrollState(switchThreshold: threshold, selectedPageBinding: selectedPage)
+        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, selectedPageBinding: selectedPage)
         self.theme = theme
         let pages = builder()
         self.pages = pages
@@ -79,12 +80,13 @@ public struct VPageView<Pages>: View where Pages: View {
     public init(
         selectedPage: Binding<Int>,
         pageSwitchThreshold: CGFloat = .defaultSwitchThreshold,
+        edgeSwipeThreshold: CGFloat = .defaultEdgeSwipeThreshold,
         theme: PageControlTheme = .default,
         @PageViewBuilder builder: () -> PageContainer<Pages>
     ) {
         // prevent values outside of 0...1
         let threshold = CGFloat(abs(pageSwitchThreshold) - floor(abs(pageSwitchThreshold)))
-        self.state = PageScrollState(switchThreshold: threshold, selectedPageBinding: selectedPage)
+        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, selectedPageBinding: selectedPage)
         self.theme = theme
         let pages = builder()
         self.pages = pages
@@ -138,6 +140,10 @@ extension CGFloat {
         #else
         return 0.5
         #endif
+    }
+
+    public static var defaultEdgeSwipeThreshold: CGFloat {
+        0.1
     }
 }
 

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -19,12 +19,13 @@ public struct HPageView<Pages>: View where Pages: View {
         selectedPage: Binding<Int>,
         pageSwitchThreshold: CGFloat = .defaultSwitchThreshold,
         edgeSwipeThreshold: CGFloat = .defaultEdgeSwipeThreshold,
+        edgeSwipingAllowed: Bool = true,
         theme: PageControlTheme = .default,
         @PageViewBuilder builder: () -> PageContainer<Pages>
     ) {
         // prevent values outside of 0...1
         let threshold = CGFloat(abs(pageSwitchThreshold) - floor(abs(pageSwitchThreshold)))
-        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, selectedPageBinding: selectedPage)
+        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, edgeSwipingAllowed: edgeSwipingAllowed, selectedPageBinding: selectedPage)
         self.theme = theme
         let pages = builder()
         self.pages = pages
@@ -59,7 +60,8 @@ public struct HPageView<Pages>: View where Pages: View {
                         let width = geometry.size.width
                         let pageCount = self.pageCount
                         self.state.horizontalDragChanged($0, viewCount: pageCount, pageWidth: width)
-                    })
+                    }),
+                     enabled: state.edgeSwipingAllowed
                     /*
                      There is a bug, where onEnded is not called, when gesture is cancelled.
                      So onEnded is handled using reset handler in `GestureState` (look `PageScrollState`)
@@ -81,12 +83,13 @@ public struct VPageView<Pages>: View where Pages: View {
         selectedPage: Binding<Int>,
         pageSwitchThreshold: CGFloat = .defaultSwitchThreshold,
         edgeSwipeThreshold: CGFloat = .defaultEdgeSwipeThreshold,
+        edgeSwipingAllowed: Bool = true,
         theme: PageControlTheme = .default,
         @PageViewBuilder builder: () -> PageContainer<Pages>
     ) {
         // prevent values outside of 0...1
         let threshold = CGFloat(abs(pageSwitchThreshold) - floor(abs(pageSwitchThreshold)))
-        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, selectedPageBinding: selectedPage)
+        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, edgeSwipingAllowed: edgeSwipingAllowed, selectedPageBinding: selectedPage)
         self.theme = theme
         let pages = builder()
         self.pages = pages
@@ -121,7 +124,8 @@ public struct VPageView<Pages>: View where Pages: View {
                         let height = geometry.size.height
                         let pageCount = self.pageCount
                         self.state.verticalDragChanged($0, viewCount: pageCount, pageHeight: height)
-                    })
+                    }),
+                     enabled: state.edgeSwipingAllowed
                     /*
                      There is a bug, where onEnded is not called, when gesture is cancelled.
                      So onEnded is handled using reset handler in `GestureState`. (look `PageScrollState`)
@@ -189,3 +193,16 @@ struct PageView_Previews: PreviewProvider {
     }
 }
 #endif
+
+extension View {
+    func simultaneousGesture<T>(_ gesture: T, including mask: GestureMask = .all, enabled: Bool) -> some View where T : Gesture {
+        Group {
+            if enabled {
+                self
+                    .simultaneousGesture(gesture, including: mask)
+            } else {
+                self
+            }
+        }
+    }
+}

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -143,7 +143,7 @@ extension CGFloat {
     }
 
     public static var defaultEdgeSwipeThreshold: CGFloat {
-        0.1
+        0.5
     }
 }
 

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -49,7 +49,7 @@ public struct HPageView<Pages>: View where Pages: View {
                         compositeView: HorizontalPageStack(pages: self.pages, geometry: geometry),
                         pageControlBuilder: pageControlBuilder)
                 .contentShape(Rectangle())
-                .highPriorityGesture(DragGesture(minimumDistance: 8.0)
+                .simultaneousGesture(DragGesture(minimumDistance: 8.0)
                     .updating(self.$stateTransaction, body: { value, state, _ in
                         state.dragValue = value
                         state.geometryProxy = geometry
@@ -110,7 +110,7 @@ public struct VPageView<Pages>: View where Pages: View {
                         compositeView: VerticalPageStack(pages: self.pages, geometry: geometry),
                         pageControlBuilder: pageControlBuilder)
                 .contentShape(Rectangle())
-                .highPriorityGesture(DragGesture(minimumDistance: 8.0)
+                .simultaneousGesture(DragGesture(minimumDistance: 8.0)
                     .updating(self.$stateTransaction, body: { value, state, _ in
                         state.dragValue = value
                         state.geometryProxy = geometry

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -182,25 +182,6 @@ extension View {
     }
 }
 
-extension View {
-    func gesture<T>(_ gesture: T, including mask: GestureMask = .all, type: PageGestureType) -> some View where T : Gesture {
-        Group {
-            if type == .standard {
-                self
-                    .gesture(gesture, including: mask)
-            } else if type == .simultaneous {
-                self
-                    .simultaneousGesture(gesture, including: mask)
-            } else if type == .highPriority {
-                self
-                    .highPriorityGesture(gesture, including: mask)
-            } else {
-                self
-            }
-        }
-    }
-}
-
 extension CGFloat {
     public static var defaultSwitchThreshold: CGFloat {
         #if os(iOS)

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -19,13 +19,13 @@ public struct HPageView<Pages>: View where Pages: View {
         selectedPage: Binding<Int>,
         pageSwitchThreshold: CGFloat = .defaultSwitchThreshold,
         edgeSwipeThreshold: CGFloat = .defaultEdgeSwipeThreshold,
-        edgeSwipingAllowed: Bool = true,
+        pageSwitchingAllowed: Bool = true,
         theme: PageControlTheme = .default,
         @PageViewBuilder builder: () -> PageContainer<Pages>
     ) {
         // prevent values outside of 0...1
         let threshold = CGFloat(abs(pageSwitchThreshold) - floor(abs(pageSwitchThreshold)))
-        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, edgeSwipingAllowed: edgeSwipingAllowed, selectedPageBinding: selectedPage)
+        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, pageSwitchingAllowed: pageSwitchingAllowed, selectedPageBinding: selectedPage)
         self.theme = theme
         let pages = builder()
         self.pages = pages
@@ -61,7 +61,7 @@ public struct HPageView<Pages>: View where Pages: View {
                         let pageCount = self.pageCount
                         self.state.horizontalDragChanged($0, viewCount: pageCount, pageWidth: width)
                     }),
-                     enabled: state.edgeSwipingAllowed
+                     enabled: state.pageSwitchingAllowed
                     /*
                      There is a bug, where onEnded is not called, when gesture is cancelled.
                      So onEnded is handled using reset handler in `GestureState` (look `PageScrollState`)
@@ -83,13 +83,13 @@ public struct VPageView<Pages>: View where Pages: View {
         selectedPage: Binding<Int>,
         pageSwitchThreshold: CGFloat = .defaultSwitchThreshold,
         edgeSwipeThreshold: CGFloat = .defaultEdgeSwipeThreshold,
-        edgeSwipingAllowed: Bool = true,
+        pageSwitchingAllowed: Bool = true,
         theme: PageControlTheme = .default,
         @PageViewBuilder builder: () -> PageContainer<Pages>
     ) {
         // prevent values outside of 0...1
         let threshold = CGFloat(abs(pageSwitchThreshold) - floor(abs(pageSwitchThreshold)))
-        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, edgeSwipingAllowed: edgeSwipingAllowed, selectedPageBinding: selectedPage)
+        self.state = PageScrollState(switchThreshold: threshold, edgeSwipeThreshold: edgeSwipeThreshold, pageSwitchingAllowed: pageSwitchingAllowed, selectedPageBinding: selectedPage)
         self.theme = theme
         let pages = builder()
         self.pages = pages
@@ -125,7 +125,7 @@ public struct VPageView<Pages>: View where Pages: View {
                         let pageCount = self.pageCount
                         self.state.verticalDragChanged($0, viewCount: pageCount, pageHeight: height)
                     }),
-                     enabled: state.edgeSwipingAllowed
+                     enabled: state.pageSwitchingAllowed
                     /*
                      There is a bug, where onEnded is not called, when gesture is cancelled.
                      So onEnded is handled using reset handler in `GestureState`. (look `PageScrollState`)


### PR DESCRIPTION
Hi there! Thanks for making this. 

I wanted to customize the page views a bit more so I added:

1. Modernize `PageScrollState` to be stored as a `@StateObject`, bumping requirement to iOS 14 and watchOS 7.
2. Make a `PageViewSettings` struct to encapsulate:
- Existing preference for `switchThreshold`
- Preference to dial in an "drag edge threshold" which is expressed as a ratio of the width or height of the page. The default value is 0.5, which allows the entire screen.
- Preference for changing gesture types (.standard, .simultaneous, .highPriority, AND disable drag events entirely)
3. Make a default `PageViewSettings` that matches the current behavior of the page view

