### PR TITLE
Minor Warnings Fix - Warnings and `functionBuilder` to` @resultBuilder`

### DIFF
--- a/Sources/PageControl.swift
+++ b/Sources/PageControl.swift
@@ -68,7 +68,7 @@ public enum PageControl {
         public let theme: PageControlTheme
         
         public var body: some View {
-            ForEach(0..<pageCount) { (i) in
+            ForEach(0..<pageCount, id: \.self) { (i) in
                  Circle()
                      .frame(width: self.theme.dotSize, height: self.theme.dotSize)
                      .foregroundColor(self.dotColor(index: i))

--- a/Sources/PageView.swift
+++ b/Sources/PageView.swift
@@ -82,7 +82,7 @@ public struct HPageView<Pages>: View where Pages: View {
         theme: PageControlTheme = .default,
         builder: @escaping (Int) -> ForEachContent
     ) where Pages == ForEach<Range<Int>, Int, ForEachContent> {
-        let forEachContainer = PageContainer(count: data.count, content: ForEach(data, content: builder))
+        let forEachContainer = PageContainer(count: data.count, content: ForEach(data, id: \.self, content: builder))
         self.init(
             selectedPage: selectedPage,
             pageCount: data.count,
@@ -232,7 +232,7 @@ public struct VPageView<Pages>: View where Pages: View {
         theme: PageControlTheme = .default,
         builder: @escaping (Int) -> ForEachContent
     ) where Pages == ForEach<Range<Int>, Int, ForEachContent> {
-        let forEachContainer = PageContainer(count: data.count, content: ForEach(data, content: builder))
+        let forEachContainer = PageContainer(count: data.count, content: ForEach(data, id: \.self, content: builder))
         self.init(
             selectedPage: selectedPage,
             pageCount: data.count,

--- a/Sources/PageViewBuilder.swift
+++ b/Sources/PageViewBuilder.swift
@@ -23,7 +23,7 @@ public struct PageContainer<Content>: View where Content: View {
     Modified version of ViewBuilder, which does the counting of child views.
     Other than that it works the same way as the original
  */
-@_functionBuilder
+@resultBuilder
 public struct PageViewBuilder {
     public static func buildBlock<Content>(_ c: Content) -> PageContainer<Content> {
         return PageContainer(count: 1, content: c)


### PR DESCRIPTION
Hello, some small updates.

- Adding` id: \.self` to remove the ForEach warnings. 
- Updating `functionBuilder` to` @resultBuilder`